### PR TITLE
feat: add edit mode toggle for monthly defaults

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -209,6 +209,7 @@ export default function App() {
     return `${d.getFullYear()}-${pad2(d.getMonth()+1)}`;
     });
   const [monthlyDefaults, setMonthlyDefaults] = useState<any[]>([]);
+  const [monthlyEditing, setMonthlyEditing] = useState(false);
 
   // UI: simple dialogs
   const [showBaselineEditor, setShowBaselineEditor] = useState(false);
@@ -1042,14 +1043,13 @@ export default function App() {
   } 
 
   function MonthlyView(){
-    const [editing, setEditing] = useState(false);
     return (
       <div className="p-4">
         <div className="flex items-center gap-2 mb-4">
           <label className="text-sm">Month</label>
           <input type="month" className="border rounded px-2 py-1" value={selectedMonth} onChange={(e)=>setSelectedMonth(e.target.value)} />
           <button className="px-3 py-1 bg-slate-200 rounded text-sm" onClick={()=>applyMonthlyDefaults(selectedMonth)}>Apply to Month</button>
-          <button className="px-3 py-1 bg-slate-200 rounded text-sm" onClick={()=>setEditing(!editing)}>{editing ? 'Done' : 'Edit'}</button>
+          <button className="px-3 py-1 bg-slate-200 rounded text-sm" onClick={()=>setMonthlyEditing(!monthlyEditing)}>{monthlyEditing ? 'Done' : 'Edit'}</button>
         </div>
         <div className="overflow-auto">
           <table className="min-w-full text-sm">
@@ -1069,7 +1069,7 @@ export default function App() {
                     const def = monthlyDefaults.find(d=>d.person_id===p.id && d.segment===seg);
                     return (
                       <td key={seg} className="p-2">
-                        <select className="border rounded px-2 py-1 w-full" value={def?.role_id||""} disabled={!editing} onChange={(e)=>{
+                        <select className="border rounded px-2 py-1 w-full" value={def?.role_id||""} disabled={!monthlyEditing} onChange={(e)=>{
                           const rid = Number(e.target.value);
                           setMonthlyDefault(p.id, seg, rid||null);
                         }}>


### PR DESCRIPTION
## Summary
- add view-only default for monthly defaults table
- enable editing via toggle button

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896bc48198c832284c2aad92ec18a0f