### PR TITLE
Use month picker for defaults copy and fix export month name

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -118,6 +118,11 @@ export default function App() {
     const d = new Date();
     return `${d.getFullYear()}-${pad2(d.getMonth()+1)}`;
   });
+  const [copyFromMonth, setCopyFromMonth] = useState<string>(() => {
+    const d = new Date();
+    d.setMonth(d.getMonth() - 1);
+    return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}`;
+  });
   const [monthlyDefaults, setMonthlyDefaults] = useState<any[]>([]);
   const [monthlyEditing, setMonthlyEditing] = useState(false);
 
@@ -126,6 +131,10 @@ export default function App() {
 
   useEffect(() => {
     if (sqlDb) loadMonthlyDefaults(selectedMonth);
+    const [y, m] = selectedMonth.split('-').map(n => parseInt(n, 10));
+    const d = new Date(y, m - 1, 1);
+    d.setMonth(d.getMonth() - 1);
+    setCopyFromMonth(`${d.getFullYear()}-${pad2(d.getMonth() + 1)}`);
   }, [sqlDb, selectedMonth]);
 
   // Load sql.js
@@ -1027,13 +1036,8 @@ export default function App() {
           <label className="text-sm">Month</label>
           <input type="month" className="border rounded px-2 py-1" value={selectedMonth} onChange={(e)=>setSelectedMonth(e.target.value)} />
           <button className="px-3 py-1 bg-slate-200 rounded text-sm" onClick={()=>applyMonthlyDefaults(selectedMonth)}>Apply to Month</button>
-          <button
-            className="px-3 py-1 bg-slate-200 rounded text-sm"
-            onClick={() => {
-              const src = prompt('Copy defaults from which month? (YYYY-MM)');
-              if (src) copyMonthlyDefaults(src, selectedMonth);
-            }}
-          >
+          <input type="month" className="border rounded px-2 py-1" value={copyFromMonth} onChange={(e)=>setCopyFromMonth(e.target.value)} />
+          <button className="px-3 py-1 bg-slate-200 rounded text-sm" onClick={()=>copyMonthlyDefaults(copyFromMonth, selectedMonth)}>
             Copy From Month
           </button>
           <button className="px-3 py-1 bg-slate-200 rounded text-sm" onClick={()=>setMonthlyEditing(!monthlyEditing)}>{monthlyEditing ? 'Done' : 'Edit'}</button>

--- a/src/excel/export-one-sheet.ts
+++ b/src/excel/export-one-sheet.ts
@@ -104,7 +104,8 @@ export async function exportMonthOneSheetXlsx(month: string): Promise<void> {
     }
   }
 
-  const monthDate = new Date(month + '-01T00:00:00Z');
+  const [y, m] = month.split('-').map(n => parseInt(n, 10));
+  const monthDate = new Date(y, m - 1, 1);
   const titleText = monthDate.toLocaleString('default', { month: 'long', year: 'numeric' });
 
   const wb = new ExcelJS.Workbook();


### PR DESCRIPTION
## Summary
- Replace text prompt with month picker when copying monthly defaults and default to previous month
- Fix one-sheet export to show correct month in title and filename

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68992fd93214832295019f7906f77875