### PR TITLE
feat: wrap role cards into columns on daily run board

### DIFF
--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -219,7 +219,10 @@ export default function DailyRunBoard({
               <span>{g.name}</span>
               <span className="text-xs text-slate-500">Theme: {g.theme_color || '-'}</span>
             </div>
-            <div className="flex-1 flex flex-col gap-3 px-3 pb-3 overflow-auto">
+            <div
+              className="flex-1 grid gap-3 px-3 pb-3 overflow-auto"
+              style={{ gridTemplateColumns: "repeat(auto-fill,minmax(250px,1fr))" }}
+            >
               {roleListForSegment(seg)
                 .filter((r) => r.group_id === g.id)
                 .map((r: any) => (


### PR DESCRIPTION
## Summary
- arrange role cards in responsive grid on DailyRunBoard
- prevent role cards from stretching by adding extra columns when board is widened

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68994fdd7c748322ad92e26f0d663c77