### PR TITLE
Remove diagnostics feature

### DIFF
--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -22,7 +22,6 @@ interface DailyRunBoardProps {
   parseYMD: (s: string) => Date;
   ymd: (d: Date) => string;
   setShowNeedsEditor: (v: boolean) => void;
-  diag: { passed: number; failed: number; details: string[] } | null;
   canEdit: boolean;
   peopleOptionsForSegment: (
     date: Date,
@@ -59,7 +58,6 @@ export default function DailyRunBoard({
   parseYMD,
   ymd,
   setShowNeedsEditor,
-  diag,
   canEdit,
   peopleOptionsForSegment,
   getRequiredFor,
@@ -331,18 +329,6 @@ export default function DailyRunBoard({
           );
         })}
       </Grid>
-
-      {diag && (
-        <div className="mt-6 border rounded bg-white p-3">
-          <div className="font-semibold mb-2">Diagnostics</div>
-          <div className="text-sm mb-2">Passed: {diag.passed} | Failed: {diag.failed}</div>
-          <ul className="text-sm list-disc ml-5 space-y-1">
-            {diag.details.map((d, i) => (
-              <li key={i}>{d}</li>
-            ))}
-          </ul>
-        </div>
-      )}
 
       {moveContext && (
         <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -14,7 +14,6 @@ interface ToolbarProps {
   status: string;
   activeTab: TabKey;
   setActiveTab: (tab: TabKey) => void;
-  runDiagnostics: () => void;
 }
 
 const useStyles = makeStyles({
@@ -42,12 +41,6 @@ const useStyles = makeStyles({
     overflow: "hidden",
     textOverflow: "ellipsis",
   },
-  actions: {
-    display: "flex",
-    alignItems: "center",
-    gap: "8px",
-    marginLeft: "auto",
-  },
   tabList: {
     marginLeft: "8px",
   }
@@ -64,7 +57,6 @@ export default function Toolbar({
   status,
   activeTab,
   setActiveTab,
-  runDiagnostics,
 }: ToolbarProps) {
   const s = useStyles();
 
@@ -93,10 +85,6 @@ export default function Toolbar({
           <Tab value="MONTHLY">Monthly Defaults</Tab>
           <Tab value="HISTORY">Crew History</Tab>
         </TabList>
-      </div>
-
-      <div className={s.actions}>
-        <Button onClick={runDiagnostics}>Run Diagnostics</Button>
       </div>
 
       <Text size={200} className={s.status}>{status}</Text>


### PR DESCRIPTION
## Summary
- remove diagnostics button from toolbar
- strip diagnostics state and self-test logic from app
- drop diagnostics display from daily run board

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/tslib)*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react' imported from vite.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689d6c7beb408322aa2ffcf908f776b4