### PR TITLE
feat: rename buffet roles to dining room

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# NewScheduler
+
+## Migrations
+
+Opening an older database will automatically rename Buffet AM/PM roles to Dining Room, while the Lunch "Buffet Supervisor" role remains unchanged.
+

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -2,6 +2,13 @@ import type { Database } from 'sql.js';
 
 export type Migration = (db: Database) => void;
 
+export const migrate3RenameBuffetToDiningRoom: Migration = (db) => {
+  db.run(`UPDATE grp SET name='Dining Room' WHERE name='Buffet';`);
+  db.run(
+    `UPDATE role SET code='DR', name=REPLACE(name,'Buffet','Dining Room') WHERE group_id=(SELECT id FROM grp WHERE name='Dining Room') AND segments<>'["Lunch"]';`
+  );
+};
+
 const migrations: Record<number, Migration> = {
   1: (db) => {
     db.run(`PRAGMA journal_mode=WAL;`);
@@ -109,7 +116,8 @@ const migrations: Record<number, Migration> = {
       FOREIGN KEY (person_id) REFERENCES person(id),
       FOREIGN KEY (role_id) REFERENCES role(id)
     );`);
-  }
+  },
+  3: migrate3RenameBuffetToDiningRoom,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- add migration to rename Buffet group and roles to Dining Room for AM/PM segments
- document automatic renaming of Buffet roles for older databases

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_689fad958f548322b6f8f5520527378f