### PR TITLE
feat: load segments from database

### DIFF
--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import GridLayout, { WidthProvider } from "react-grid-layout";
 import "react-grid-layout/css/styles.css";
 import "react-resizable/css/styles.css";
-import type { Segment } from "../config/domain";
+import type { Segment, SegmentRow } from "../services/segments";
 import PersonName from "./PersonName";
 
 const Grid = WidthProvider(GridLayout);
@@ -11,6 +11,7 @@ interface DailyRunBoardProps {
   activeRunSegment: Exclude<Segment, "Early">;
   setActiveRunSegment: (seg: Exclude<Segment, "Early">) => void;
   groups: any[];
+  segments: SegmentRow[];
   lockEmail: string;
   sqlDb: any | null;
   all: (sql: string, params?: any[], db?: any) => any[];
@@ -47,6 +48,7 @@ export default function DailyRunBoard({
   activeRunSegment,
   setActiveRunSegment,
   groups,
+  segments,
   lockEmail,
   sqlDb,
   all,
@@ -270,17 +272,19 @@ export default function DailyRunBoard({
           />
         </div>
         <div className="flex gap-2">
-          {["AM", "Lunch", "PM"].map((s) => (
-            <button
-              key={s}
-              className={`px-3 py-1 rounded text-sm ${
-                activeRunSegment === s ? "bg-indigo-600 text-white" : "bg-slate-200"
-              }`}
-              onClick={() => setActiveRunSegment(s as Exclude<Segment, "Early">)}
-            >
-              {s}
-            </button>
-          ))}
+          {segments
+            .filter((s) => s.name !== "Early")
+            .map((s) => (
+              <button
+                key={s.name}
+                className={`px-3 py-1 rounded text-sm ${
+                  activeRunSegment === s.name ? "bg-indigo-600 text-white" : "bg-slate-200"
+                }`}
+                onClick={() => setActiveRunSegment(s.name as Exclude<Segment, "Early">)}
+              >
+                {s.name}
+              </button>
+            ))}
         </div>
         <div className="flex flex-wrap gap-2 lg:ml-auto">
           <button

--- a/src/config/domain.ts
+++ b/src/config/domain.ts
@@ -1,5 +1,4 @@
-export const SEGMENTS = ["Early", "AM", "Lunch", "PM"] as const;
-export type Segment = (typeof SEGMENTS)[number];
+import type { Segment } from "../services/segments";
 
 export const GROUPS: Record<string, { theme: string; color: string }> = {
   "Bakery": { theme: "4. Purple", color: "#e9d5ff" },
@@ -70,28 +69,3 @@ export const ROLE_SEED: Array<{ code: string; name: string; group: keyof typeof 
   { code: "MC", name: "Consolidation Table", group: "Main Course", segments: ["Lunch"] },
   { code: "VEG", name: "Consolidation Table", group: "Veggie Room", segments: ["Lunch"] },
 ];
-
-export function baseSegmentTimes(date: Date, hasLunch: boolean, hasEarly: boolean): Record<Exclude<Segment, "Early">, { start: Date; end: Date }> {
-  // All times in America/New_York implicit local
-  const day = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  const mk = (h: number, m: number) => new Date(day.getFullYear(), day.getMonth(), day.getDate(), h, m, 0, 0);
-
-  if (hasLunch) {
-    // Lunch day pattern
-    const am = { start: mk(8, 0), end: mk(11, 0) };
-    const lunch = { start: mk(11, 0), end: mk(13, 0) };
-    const pm = { start: mk(14, 0), end: mk(hasEarly ? 16 : 17, 0) };
-    return { AM: am, Lunch: lunch, PM: pm };
-  } else {
-    const am = { start: mk(8, 0), end: mk(12, 0) };
-    const pm = { start: mk(13, 0), end: mk(hasEarly ? 16 : 17, 0) };
-    return { AM: am, Lunch: { start: mk(11, 0), end: mk(13, 0) }, PM: pm }; // Lunch unused if no Lunch assignment; kept for reference
-  }
-}
-
-export function earlyTimes(date: Date) {
-  const day = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  const mk = (h: number, m: number) => new Date(day.getFullYear(), day.getMonth(), day.getDate(), h, m, 0, 0);
-  return { start: mk(6, 20), end: mk(7, 20) };
-}
-

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -9,6 +9,22 @@ export const migrate3RenameBuffetToDiningRoom: Migration = (db) => {
   );
 };
 
+export const migrate4AddSegments: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS segment (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      start_time TEXT NOT NULL,
+      end_time TEXT NOT NULL,
+      ordering INTEGER NOT NULL UNIQUE
+    );`);
+  db.run(`INSERT INTO segment (name, start_time, end_time, ordering) VALUES
+      ('Early','06:20','07:20',0),
+      ('AM','08:00','11:00',1),
+      ('Lunch','11:00','13:00',2),
+      ('PM','14:00','17:00',3)
+    ON CONFLICT(name) DO NOTHING;`);
+};
+
 const migrations: Record<number, Migration> = {
   1: (db) => {
     db.run(`PRAGMA journal_mode=WAL;`);
@@ -118,6 +134,7 @@ const migrations: Record<number, Migration> = {
     );`);
   },
   3: migrate3RenameBuffetToDiningRoom,
+  4: migrate4AddSegments,
 };
 
 export function addMigration(version: number, fn: Migration) {

--- a/src/services/segments.ts
+++ b/src/services/segments.ts
@@ -1,0 +1,49 @@
+import type { Database } from 'sql.js';
+
+export interface SegmentRow {
+  id: number;
+  name: string;
+  start_time: string; // HH:MM
+  end_time: string;   // HH:MM
+  ordering: number;
+}
+
+export type Segment = SegmentRow['name'];
+
+export function listSegments(db: Database): SegmentRow[] {
+  const res = db.exec(`SELECT id, name, start_time, end_time, ordering FROM segment ORDER BY ordering`);
+  const values = res[0]?.values || [];
+  return values.map((row) => ({
+    id: Number(row[0]),
+    name: String(row[1]),
+    start_time: String(row[2]),
+    end_time: String(row[3]),
+    ordering: Number(row[4]),
+  }));
+}
+
+export function createSegment(db: Database, data: Omit<SegmentRow, 'id'>): number {
+  db.run(
+    `INSERT INTO segment (name, start_time, end_time, ordering) VALUES (?,?,?,?)`,
+    [data.name, data.start_time, data.end_time, data.ordering]
+  );
+  const res = db.exec(`SELECT last_insert_rowid()`);
+  return Number(res[0]?.values?.[0]?.[0] || 0);
+}
+
+export function updateSegment(db: Database, id: number, data: Partial<Omit<SegmentRow, 'id'>>): void {
+  const fields: string[] = [];
+  const params: any[] = [];
+  if (data.name !== undefined) { fields.push('name=?'); params.push(data.name); }
+  if (data.start_time !== undefined) { fields.push('start_time=?'); params.push(data.start_time); }
+  if (data.end_time !== undefined) { fields.push('end_time=?'); params.push(data.end_time); }
+  if (data.ordering !== undefined) { fields.push('ordering=?'); params.push(data.ordering); }
+  if (!fields.length) return;
+  params.push(id);
+  db.run(`UPDATE segment SET ${fields.join(', ')} WHERE id=?`, params);
+}
+
+export function deleteSegment(db: Database, id: number): void {
+  db.run(`DELETE FROM segment WHERE id=?`, [id]);
+}
+


### PR DESCRIPTION
## Summary
- add migration for `segment` table and seed initial segments
- implement `segments` service with CRUD helpers
- load segments from DB at runtime and compute segment times dynamically
- derive segment types from DB data and update components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react'; npm install 403)*


------
https://chatgpt.com/codex/tasks/task_e_689fb65a91188322b38443fa065826db