### PR TITLE
Add group/role editors and dynamic group colors

### DIFF
--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -319,7 +319,8 @@ export default function DailyRunBoard({
             >
               <div className="font-semibold flex items-center justify-between mb-2 drag-handle px-3 pt-3">
                 <span>{g.name}</span>
-                <span className="text-xs text-slate-500">Theme: {g.theme_color || '-'}</span>
+                <span className="text-xs text-slate-500">Theme: {g.theme || '-'}</span>
+                <span className="text-xs text-slate-500 ml-2">Color: {g.custom_color || '-'}</span>
               </div>
               <div
                 className="flex-1 grid gap-3 px-3 pb-3 overflow-auto"

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from "react";
+
+interface GroupEditorProps {
+  all: (sql: string, params?: any[]) => any[];
+  run: (sql: string, params?: any[]) => void;
+  refresh: () => void;
+}
+
+export default function GroupEditor({ all, run, refresh }: GroupEditorProps) {
+  const empty = { name: "", theme: "", custom_color: "" };
+  const [groups, setGroups] = useState<any[]>([]);
+  const [editing, setEditing] = useState<any | null>(null);
+  const [formVisible, setFormVisible] = useState(false);
+  const [form, setForm] = useState(empty);
+
+  function load() {
+    setGroups(all(`SELECT id,name,theme,custom_color FROM grp ORDER BY name`));
+  }
+
+  useEffect(load, []);
+
+  function startAdd() {
+    setEditing(null);
+    setForm(empty);
+    setFormVisible(true);
+  }
+
+  function startEdit(g: any) {
+    setEditing(g);
+    setForm({ name: g.name, theme: g.theme || "", custom_color: g.custom_color || "" });
+    setFormVisible(true);
+  }
+
+  function save() {
+    if (editing) {
+      run(`UPDATE grp SET name=?, theme=?, custom_color=? WHERE id=?`, [form.name, form.theme || null, form.custom_color || null, editing.id]);
+    } else {
+      run(`INSERT INTO grp (name, theme, custom_color) VALUES (?,?,?)`, [form.name, form.theme || null, form.custom_color || null]);
+    }
+    load();
+    refresh();
+    setFormVisible(false);
+    setEditing(null);
+    setForm(empty);
+  }
+
+  function cancel() {
+    setFormVisible(false);
+    setEditing(null);
+    setForm(empty);
+  }
+
+  function remove(id: number) {
+    if (!window.confirm("Delete group?")) return;
+    run(`DELETE FROM role WHERE group_id=?`, [id]);
+    run(`DELETE FROM grp WHERE id=?`, [id]);
+    load();
+    refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="font-semibold text-lg">Groups</div>
+        <button className="px-3 py-2 bg-emerald-700 text-white rounded" onClick={startAdd}>
+          Add Group
+        </button>
+      </div>
+
+      <div className="border rounded-lg overflow-auto max-h-[40vh] shadow w-full">
+        <table className="min-w-full text-sm divide-y divide-slate-200">
+          <thead className="bg-slate-100 sticky top-0">
+            <tr>
+              <th className="p-2 text-left">Name</th>
+              <th className="p-2 text-left">Theme</th>
+              <th className="p-2 text-left">Color</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {groups.map((g: any) => (
+              <tr key={g.id} className="odd:bg-white even:bg-slate-50">
+                <td className="p-2">{g.name}</td>
+                <td className="p-2">{g.theme || ""}</td>
+                <td className="p-2">{g.custom_color || ""}</td>
+                <td className="p-2 text-right space-x-2">
+                  <button className="text-blue-600" onClick={() => startEdit(g)}>Edit</button>
+                  <button className="text-red-600" onClick={() => remove(g.id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {formVisible && (
+        <div className="space-y-2">
+          <input
+            className="border rounded px-2 py-1 w-full"
+            placeholder="Name"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+          />
+          <input
+            className="border rounded px-2 py-1 w-full"
+            placeholder="Theme"
+            value={form.theme}
+            onChange={(e) => setForm({ ...form, theme: e.target.value })}
+          />
+          <input
+            className="border rounded px-2 py-1 w-full"
+            placeholder="Custom Color"
+            value={form.custom_color}
+            onChange={(e) => setForm({ ...form, custom_color: e.target.value })}
+          />
+          <div className="flex gap-2">
+            <button className="px-3 py-2 bg-emerald-700 text-white rounded" onClick={save}>
+              Save
+            </button>
+            <button className="px-3 py-2 border rounded" onClick={cancel}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/RoleEditor.tsx
+++ b/src/components/RoleEditor.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from "react";
+import type { SegmentRow } from "../services/segments";
+
+interface RoleEditorProps {
+  all: (sql: string, params?: any[]) => any[];
+  run: (sql: string, params?: any[]) => void;
+  refresh: () => void;
+  segments: SegmentRow[];
+}
+
+export default function RoleEditor({ all, run, refresh, segments }: RoleEditorProps) {
+  const [roles, setRoles] = useState<any[]>([]);
+  const [groups, setGroups] = useState<any[]>([]);
+  const [editing, setEditing] = useState<any | null>(null);
+  const [formVisible, setFormVisible] = useState(false);
+
+  function load() {
+    setRoles(
+      all(`SELECT r.id,r.code,r.name,r.group_id,r.segments,g.name as group_name FROM role r JOIN grp g ON g.id=r.group_id ORDER BY g.name,r.name`)
+        .map((r: any) => ({ ...r, segs: new Set<string>(JSON.parse(r.segments)) }))
+    );
+    setGroups(all(`SELECT id,name FROM grp ORDER BY name`));
+  }
+
+  useEffect(load, []);
+
+  function startAdd() {
+    setEditing({ id: null, code: "", name: "", group_id: groups[0]?.id || 0, segs: new Set<string>() });
+    setFormVisible(true);
+  }
+
+  function startEdit(r: any) {
+    setEditing({ ...r, segs: new Set<string>(r.segs) });
+    setFormVisible(true);
+  }
+
+  function toggleSeg(seg: string) {
+    if (!editing) return;
+    const s = new Set(editing.segs);
+    if (s.has(seg)) s.delete(seg); else s.add(seg);
+    setEditing({ ...editing, segs: s });
+  }
+
+  function save() {
+    if (!editing) return;
+    const segArr = Array.from(editing.segs);
+    if (editing.id) {
+      run(`UPDATE role SET code=?, name=?, group_id=?, segments=? WHERE id=?`, [editing.code, editing.name, editing.group_id, JSON.stringify(segArr), editing.id]);
+    } else {
+      run(`INSERT INTO role (code,name,group_id,segments) VALUES (?,?,?,?)`, [editing.code, editing.name, editing.group_id, JSON.stringify(segArr)]);
+    }
+    load();
+    refresh();
+    setFormVisible(false);
+    setEditing(null);
+  }
+
+  function cancel() {
+    setFormVisible(false);
+    setEditing(null);
+  }
+
+  function remove(id: number) {
+    if (!window.confirm("Delete role?")) return;
+    run(`DELETE FROM role WHERE id=?`, [id]);
+    load();
+    refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="font-semibold text-lg">Roles</div>
+        <button className="px-3 py-2 bg-emerald-700 text-white rounded" onClick={startAdd}>Add Role</button>
+      </div>
+
+      <div className="border rounded-lg overflow-auto max-h-[40vh] shadow w-full">
+        <table className="min-w-full text-sm divide-y divide-slate-200">
+          <thead className="bg-slate-100 sticky top-0">
+            <tr>
+              <th className="p-2 text-left">Code</th>
+              <th className="p-2 text-left">Name</th>
+              <th className="p-2 text-left">Group</th>
+              <th className="p-2 text-left">Segments</th>
+              <th className="p-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {roles.map((r: any) => (
+              <tr key={r.id} className="odd:bg-white even:bg-slate-50">
+                <td className="p-2">{r.code}</td>
+                <td className="p-2">{r.name}</td>
+                <td className="p-2">{r.group_name}</td>
+                <td className="p-2">{Array.from(r.segs).join(", ")}</td>
+                <td className="p-2 text-right space-x-2">
+                  <button className="text-blue-600" onClick={() => startEdit(r)}>Edit</button>
+                  <button className="text-red-600" onClick={() => remove(r.id)}>Delete</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {formVisible && editing && (
+        <div className="space-y-2">
+          <input
+            className="border rounded px-2 py-1 w-full"
+            placeholder="Code"
+            value={editing.code}
+            onChange={(e) => setEditing({ ...editing, code: e.target.value })}
+          />
+          <input
+            className="border rounded px-2 py-1 w-full"
+            placeholder="Name"
+            value={editing.name}
+            onChange={(e) => setEditing({ ...editing, name: e.target.value })}
+          />
+          <select
+            className="border rounded px-2 py-1 w-full"
+            value={editing.group_id}
+            onChange={(e) => setEditing({ ...editing, group_id: Number(e.target.value) })}
+          >
+            {groups.map((g: any) => (
+              <option key={g.id} value={g.id}>{g.name}</option>
+            ))}
+          </select>
+          <div className="flex gap-2">
+            {segments.map((s) => (
+              <label key={s.name} className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={editing.segs.has(s.name)}
+                  onChange={() => toggleSeg(s.name)}
+                />
+                {s.name}
+              </label>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <button className="px-3 py-2 bg-emerald-700 text-white rounded" onClick={save}>Save</button>
+            <button className="px-3 py-2 border rounded" onClick={cancel}>Cancel</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button, Tab, TabList, Tooltip, Spinner, Text, makeStyles, tokens } from "@fluentui/react-components";
 
-type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY";
+type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "SETUP";
 
 interface ToolbarProps {
   ready: boolean;
@@ -84,6 +84,7 @@ export default function Toolbar({
           <Tab value="EXPORT">Export Preview</Tab>
           <Tab value="MONTHLY">Monthly Defaults</Tab>
           <Tab value="HISTORY">Crew History</Tab>
+          <Tab value="SETUP">Setup</Tab>
         </TabList>
       </div>
 


### PR DESCRIPTION
## Summary
- store both theme and custom color for groups and seed initial data during migrations
- add GroupEditor and RoleEditor components for managing groups and roles
- remove hard-coded group/role constants and query database dynamically

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find package '@vitejs/plugin-react')


------
https://chatgpt.com/codex/tasks/task_e_689fb994e8548322b82a1d15a40c41b9