### PR TITLE
Expose custom time segments in scheduler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,7 +138,7 @@ export default function App() {
 
   useEffect(() => {
     if (segments.length && !segments.find(s => s.name === activeRunSegment)) {
-      const first = segments.find(s => s.name !== "Early") || segments[0];
+      const first = segments[0];
       if (first) setActiveRunSegment(first.name as Segment);
     }
   }, [segments]);
@@ -195,117 +195,7 @@ export default function App() {
     if (!SQL) return;
     const db = new SQL.Database();
     applyMigrations(db);
-    const segRows = listSegments(db);
-    const segmentCheck = segRows.map(s => `'${s.name}'`).join(',');
-    // Schema
-    db.run(`PRAGMA journal_mode=WAL;`);
-    db.run(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT);`);
-    db.run(`CREATE TABLE IF NOT EXISTS person (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      last_name TEXT NOT NULL,
-      first_name TEXT NOT NULL,
-      work_email TEXT NOT NULL UNIQUE,
-      brother_sister TEXT CHECK(brother_sister IN ('Brother','Sister')),
-      commuter INTEGER NOT NULL DEFAULT 0,
-      active INTEGER NOT NULL DEFAULT 1,
-      avail_mon TEXT CHECK(avail_mon IN ('U','AM','PM','B')) DEFAULT 'U',
-      avail_tue TEXT CHECK(avail_tue IN ('U','AM','PM','B')) DEFAULT 'U',
-      avail_wed TEXT CHECK(avail_wed IN ('U','AM','PM','B')) DEFAULT 'U',
-      avail_thu TEXT CHECK(avail_thu IN ('U','AM','PM','B')) DEFAULT 'U',
-      avail_fri TEXT CHECK(avail_fri IN ('U','AM','PM','B')) DEFAULT 'U'
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS grp (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      name TEXT NOT NULL UNIQUE,
-      theme TEXT,
-      custom_color TEXT
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS role (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      code TEXT NOT NULL,
-      name TEXT NOT NULL,
-      group_id INTEGER NOT NULL,
-      segments TEXT NOT NULL,
-      UNIQUE(code, name, group_id),
-      FOREIGN KEY (group_id) REFERENCES grp(id)
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS training (
-      person_id INTEGER NOT NULL,
-      role_id INTEGER NOT NULL,
-      status TEXT CHECK(status IN ('Not trained','In training','Qualified')) NOT NULL DEFAULT 'Not trained',
-      PRIMARY KEY (person_id, role_id),
-      FOREIGN KEY (person_id) REFERENCES person(id),
-      FOREIGN KEY (role_id) REFERENCES role(id)
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS assignment (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      date TEXT NOT NULL, -- YYYY-MM-DD
-      person_id INTEGER NOT NULL,
-      role_id INTEGER NOT NULL,
-      segment TEXT CHECK(segment IN (${segmentCheck})) NOT NULL,
-      FOREIGN KEY (person_id) REFERENCES person(id),
-      FOREIGN KEY (role_id) REFERENCES role(id)
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS monthly_default (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      month TEXT NOT NULL, -- YYYY-MM
-      person_id INTEGER NOT NULL,
-      segment TEXT CHECK(segment IN (${segmentCheck})) NOT NULL,
-      role_id INTEGER NOT NULL,
-      UNIQUE(month, person_id, segment),
-      FOREIGN KEY (person_id) REFERENCES person(id),
-      FOREIGN KEY (role_id) REFERENCES role(id)
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS monthly_default_day (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      month TEXT NOT NULL,
-      person_id INTEGER NOT NULL,
-      weekday INTEGER NOT NULL,
-      segment TEXT CHECK(segment IN (${segmentCheck})) NOT NULL,
-      role_id INTEGER NOT NULL,
-      UNIQUE(month, person_id, weekday, segment),
-      FOREIGN KEY (person_id) REFERENCES person(id),
-      FOREIGN KEY (role_id) REFERENCES role(id)
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS needs_baseline (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      group_id INTEGER NOT NULL,
-      role_id INTEGER NOT NULL,
-      segment TEXT CHECK(segment IN (${segmentCheck})) NOT NULL,
-      required INTEGER NOT NULL DEFAULT 0,
-      UNIQUE(group_id, role_id, segment)
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS needs_override (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      date TEXT NOT NULL,
-      group_id INTEGER NOT NULL,
-      role_id INTEGER NOT NULL,
-      segment TEXT CHECK(segment IN (${segmentCheck})) NOT NULL,
-      required INTEGER NOT NULL,
-      UNIQUE(date, group_id, role_id, segment)
-    );`);
-
-    db.run(`CREATE TABLE IF NOT EXISTS timeoff (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      person_id INTEGER NOT NULL,
-      start_ts TEXT NOT NULL, -- ISO string
-      end_ts TEXT NOT NULL,
-      reason TEXT,
-      source TEXT DEFAULT 'TeamsImport',
-      FOREIGN KEY (person_id) REFERENCES person(id)
-    );`);
-
-    // Soft lock cleared
     db.run(`INSERT OR REPLACE INTO meta (key,value) VALUES ('lock','{}')`);
-
     setSqlDb(db);
     setStatus("New DB created (unsaved). Use Save As to write a .db file.");
     refreshCaches(db);
@@ -322,30 +212,6 @@ export default function App() {
       const buf = await file.arrayBuffer();
       const db = new SQL.Database(new Uint8Array(buf));
       applyMigrations(db);
-      const segRows = listSegments(db);
-      const segmentCheck = segRows.map(s => `'${s.name}'`).join(',');
-      db.run(`CREATE TABLE IF NOT EXISTS monthly_default (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        month TEXT NOT NULL,
-        person_id INTEGER NOT NULL,
-        segment TEXT CHECK(segment IN (${segmentCheck})) NOT NULL,
-        role_id INTEGER NOT NULL,
-        UNIQUE(month, person_id, segment),
-        FOREIGN KEY (person_id) REFERENCES person(id),
-        FOREIGN KEY (role_id) REFERENCES role(id)
-      );`);
-
-      db.run(`CREATE TABLE IF NOT EXISTS monthly_default_day (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        month TEXT NOT NULL,
-        person_id INTEGER NOT NULL,
-        weekday INTEGER NOT NULL,
-        segment TEXT CHECK(segment IN (${segmentCheck})) NOT NULL,
-        role_id INTEGER NOT NULL,
-        UNIQUE(month, person_id, weekday, segment),
-        FOREIGN KEY (person_id) REFERENCES person(id),
-        FOREIGN KEY (role_id) REFERENCES role(id)
-      );`);
 
       if (readOnly) {
         setLockedBy("(read-only)");
@@ -597,7 +463,7 @@ export default function App() {
     setMonthlyOverrides(ov);
   }
 
-  function setMonthlyDefault(personId: number, segment: Exclude<Segment,'Early'>, roleId: number | null) {
+  function setMonthlyDefault(personId: number, segment: Segment, roleId: number | null) {
     if (!sqlDb) return;
     if (roleId) {
       run(`INSERT INTO monthly_default (month, person_id, segment, role_id) VALUES (?,?,?,?)
@@ -610,7 +476,7 @@ export default function App() {
     loadMonthlyDefaults(selectedMonth);
   }
 
-  function setWeeklyOverride(personId: number, weekday: number, segment: Exclude<Segment,'Early'>, roleId: number | null) {
+  function setWeeklyOverride(personId: number, weekday: number, segment: Segment, roleId: number | null) {
     if (!sqlDb) return;
     if (roleId) {
       run(`INSERT INTO monthly_default_day (month, person_id, weekday, segment, role_id) VALUES (?,?,?,?,?)
@@ -623,7 +489,7 @@ export default function App() {
     loadMonthlyDefaults(selectedMonth);
   }
 
-  function setMonthlyDefaultForMonth(month: string, personId: number, segment: Exclude<Segment,'Early'>, roleId: number | null) {
+  function setMonthlyDefaultForMonth(month: string, personId: number, segment: Segment, roleId: number | null) {
     if (!sqlDb) return;
     if (roleId) {
       run(`INSERT INTO monthly_default (month, person_id, segment, role_id) VALUES (?,?,?,?)
@@ -677,16 +543,17 @@ export default function App() {
         const wdNum = d.getDay(); // 1=Mon..5=Fri
         const availField = wdName === 'Monday'? 'avail_mon' : wdName === 'Tuesday'? 'avail_tue' : wdName === 'Wednesday'? 'avail_wed' : wdName === 'Thursday'? 'avail_thu' : 'avail_fri';
         const avail = person[availField];
-        for (const seg of ['AM','Lunch','PM'] as const) {
+        for (const seg of segments.map(s => s.name as Segment)) {
           let roleId = overrideMap.get(`${person.id}|${wdNum}|${seg}`);
           if (roleId === undefined) roleId = defaultMap.get(`${person.id}|${seg}`);
           if (!roleId) continue;
           let ok = false;
-          if (seg === 'AM') ok = avail === 'AM' || avail === 'B';
+          if (seg === 'AM' || seg === 'Early') ok = avail === 'AM' || avail === 'B';
           else if (seg === 'PM') ok = avail === 'PM' || avail === 'B';
           else if (seg === 'Lunch') ok = avail === 'AM' || avail === 'PM' || avail === 'B';
+          else ok = avail === 'AM' || avail === 'PM' || avail === 'B';
           if (!ok) continue;
-          if (isSegmentBlockedByTimeOff(person.id, d, seg)) continue;
+          if (seg !== 'Early' && isSegmentBlockedByTimeOff(person.id, d, seg)) continue;
           run(`INSERT OR REPLACE INTO assignment (date, person_id, role_id, segment) VALUES (?,?,?,?)`,
               [ymd(d), person.id, roleId, seg]);
         }
@@ -699,7 +566,10 @@ export default function App() {
   async function exportMonthlyDefaults(month: string) {
     if (!sqlDb) return;
     const headers = [
-      'Last Name','First Name','AM Role','Lunch Role','PM Role','B/S','Commute','Active',
+      'Last Name',
+      'First Name',
+      ...segments.map(s => `${s.name} Role`),
+      'B/S','Commute','Active',
       'Mon','Tue','Wed','Thu','Fri'
     ];
 
@@ -723,7 +593,8 @@ export default function App() {
 
     const headerHtml = headers.map(h => `<th>${escapeHtml(h)}</th>`).join('');
     const bodyHtml = people.map((p:any) => {
-      const roleTds = ['AM','Lunch','PM'].map(seg => {
+      const roleTds = segments.map(s => {
+        const seg = s.name as Segment;
         const def = monthlyDefaults.find(d => d.person_id===p.id && d.segment===seg);
         const role = roles.find(r => r.id===def?.role_id);
         const group = groups.find(g => g.id === role?.group_id);
@@ -931,7 +802,7 @@ async function exportShifts() {
   const canSave = !!sqlDb && (!lockedBy || lockedBy === lockEmail);
   const selectedDateObj = useMemo(()=>parseMDY(selectedDate),[selectedDate]);
 
-  function peopleOptionsForSegment(date: Date, segment: Exclude<Segment, "Early">, role: any) {
+  function peopleOptionsForSegment(date: Date, segment: Segment, role: any) {
     // Determine weekday availability field
     const wd = weekdayName(date);
     const availField =
@@ -959,10 +830,14 @@ async function exportShifts() {
     return rows
       .filter((p: any) => {
         const avail = p[availField] as "U" | "AM" | "PM" | "B";
-        const availOk =
-          (segment === "AM" && (avail === "AM" || avail === "B")) ||
-          (segment === "PM" && (avail === "PM" || avail === "B")) ||
-          (segment === "Lunch" && (avail === "AM" || avail === "PM" || avail === "B"));
+        let availOk: boolean;
+        if (segment === "AM" || segment === "Early") {
+          availOk = avail === "AM" || avail === "B";
+        } else if (segment === "PM") {
+          availOk = avail === "PM" || avail === "B";
+        } else {
+          availOk = avail === "AM" || avail === "PM" || avail === "B";
+        }
         if (!availOk) return false;
 
         if (segment !== "Early" && isSegmentBlockedByTimeOff(p.id, date, segment)) return false;
@@ -1023,16 +898,14 @@ async function exportShifts() {
     );
   }
     function MonthlyView(){
-    const [sortKey, setSortKey] = useState<
-      'name' | 'email' | 'brother_sister' | 'commuter' | 'active' |
-      'avail_mon' | 'avail_tue' | 'avail_wed' | 'avail_thu' | 'avail_fri' |
-      'AM' | 'Lunch' | 'PM'
-    >('name');
+    const [sortKey, setSortKey] = useState<string>('name');
     const [sortDir, setSortDir] = useState<'asc'|'desc'>('asc');
     const [filterText, setFilterText] = useState('');
     const [weekdayPerson, setWeekdayPerson] = useState<number|null>(null);
     const [activeOnly, setActiveOnly] = useState(false);
     const [commuterOnly, setCommuterOnly] = useState(false);
+
+    const segmentNames = useMemo(() => segments.map(s => s.name as Segment), [segments]);
 
     const viewPeople = useMemo(()=>{
       const low = filterText.toLowerCase();
@@ -1040,7 +913,7 @@ async function exportShifts() {
         .filter((p:any)=>!activeOnly || p.active)
         .filter((p:any)=>!commuterOnly || p.commuter)
         .filter((p:any)=>{
-          const roleNames = ['AM','Lunch','PM'].map(seg=>{
+          const roleNames = segmentNames.map(seg=>{
             const def = monthlyDefaults.find(d=>d.person_id===p.id && d.segment===seg);
             const role = roles.find(r=>r.id===def?.role_id);
             return role?.name || '';
@@ -1085,29 +958,30 @@ async function exportShifts() {
           case 'avail_wed': av = a.avail_wed; bv = b.avail_wed; break;
           case 'avail_thu': av = a.avail_thu; bv = b.avail_thu; break;
           case 'avail_fri': av = a.avail_fri; bv = b.avail_fri; break;
-          case 'AM':
-          case 'Lunch':
-          case 'PM':
-            const defA = monthlyDefaults.find(d=>d.person_id===a.id && d.segment===field);
-            const defB = monthlyDefaults.find(d=>d.person_id===b.id && d.segment===field);
-            const roleA = roles.find(r=>r.id===defA?.role_id)?.name || '';
-            const roleB = roles.find(r=>r.id===defB?.role_id)?.name || '';
-            av = roleA; bv = roleB; break;
           default:
-            av = ''; bv = ''; break;
+            if (segmentNames.includes(field)) {
+              const defA = monthlyDefaults.find(d=>d.person_id===a.id && d.segment===field);
+              const defB = monthlyDefaults.find(d=>d.person_id===b.id && d.segment===field);
+              const roleA = roles.find(r=>r.id===defA?.role_id)?.name || '';
+              const roleB = roles.find(r=>r.id===defB?.role_id)?.name || '';
+              av = roleA; bv = roleB;
+            } else {
+              av = ''; bv = '';
+            }
+            break;
         }
         if (av < bv) return sortDir === 'asc' ? -1 : 1;
         if (av > bv) return sortDir === 'asc' ? 1 : -1;
         return 0;
       });
       return sorted;
-    }, [people, monthlyDefaults, roles, filterText, sortKey, sortDir, activeOnly, commuterOnly]);
+    }, [people, monthlyDefaults, roles, filterText, sortKey, sortDir, activeOnly, commuterOnly, segmentNames]);
 
     function WeeklyOverrideModal({ personId, onClose }: { personId:number; onClose:()=>void }) {
       const person = people.find(p=>p.id===personId);
       if (!person) return null;
       const weekdays = [1,2,3,4,5];
-      const segments = ['AM','Lunch','PM'] as const;
+      const segNames = segmentNames;
       return (
         <div className="fixed inset-0 bg-black/40 z-40 flex items-center justify-center" onClick={onClose}>
           <div className="bg-white rounded shadow-lg p-4" onClick={e=>e.stopPropagation()}>
@@ -1125,7 +999,7 @@ async function exportShifts() {
                 </tr>
               </thead>
               <tbody>
-                {segments.map(seg=> (
+                {segNames.map(seg=> (
                   <tr key={seg}>
                     <td className="p-1 font-medium">{seg}</td>
                     {weekdays.map(w => {
@@ -1183,9 +1057,9 @@ async function exportShifts() {
             <Option value="avail_wed">Wed</Option>
             <Option value="avail_thu">Thu</Option>
             <Option value="avail_fri">Fri</Option>
-            <Option value="AM">AM Role</Option>
-            <Option value="Lunch">Lunch Role</Option>
-            <Option value="PM">PM Role</Option>
+            {segmentNames.map(seg => (
+              <Option key={seg} value={seg}>{seg} Role</Option>
+            ))}
           </Dropdown>
           <Button onClick={()=>setSortDir(sortDir==='asc'?'desc':'asc')}>{sortDir==='asc'?'Asc':'Desc'}</Button>
           <Checkbox label="Active" checked={activeOnly} onChange={(_, data)=>setActiveOnly(!!data.checked)} />
@@ -1196,7 +1070,7 @@ async function exportShifts() {
             <thead className="bg-slate-100">
               <tr>
                 <th className="p-2 text-left">Name</th>
-                {(['AM','Lunch','PM'] as const).map(seg=> (
+                {segmentNames.map(seg=> (
                   <th key={seg} className="p-2 text-left">{seg}</th>
                 ))}
               </tr>
@@ -1212,20 +1086,27 @@ async function exportShifts() {
                       </button>
                     )}
                   </td>
-                  {(['AM','Lunch','PM'] as const).map(seg => {
-                    const def = monthlyDefaults.find(d=>d.person_id===p.id && d.segment===seg);
-                    return (
-                      <td key={seg} className="p-2">
-                        <select className="border rounded px-2 py-1 w-full" value={def?.role_id||""} disabled={!monthlyEditing} onChange={(e)=>{
-                          const rid = Number(e.target.value);
-                          setMonthlyDefault(p.id, seg, rid||null);
-                        }}>
-                          <option value="">--</option>
-                          {roleListForSegment(seg).map((r:any)=>(<option key={r.id} value={r.id}>{r.name}</option>))}
-                        </select>
-                      </td>
-                    );
-                  })}
+                    {segmentNames.map(seg => {
+                      const def = monthlyDefaults.find(d => d.person_id === p.id && d.segment === seg);
+                      return (
+                        <td key={seg} className="p-2">
+                          <select
+                            className="border rounded px-2 py-1 w-full"
+                            value={def?.role_id?.toString() || ""}
+                            disabled={!monthlyEditing}
+                            onChange={(e) => {
+                              const rid = parseInt(e.target.value, 10);
+                              setMonthlyDefault(p.id, seg, isNaN(rid) ? null : rid);
+                            }}
+                          >
+                            <option value="">--</option>
+                            {roleListForSegment(seg).map((r: any) => (
+                              <option key={r.id} value={r.id.toString()}>{r.name}</option>
+                            ))}
+                          </select>
+                        </td>
+                      );
+                    })}
                 </tr>
               ))}
             </tbody>
@@ -1241,16 +1122,13 @@ async function exportShifts() {
   function CrewHistoryView(){
     const [defs, setDefs] = useState<any[]>([]);
     const [filter, setFilter] = useState("");
-    const [showSeg, setShowSeg] = useState({ AM: true, Lunch: true, PM: true });
+    const segmentNames = useMemo(() => segments.map(s => s.name as Segment), [segments]);
+    const [showSeg, setShowSeg] = useState<Record<string, boolean>>(() => Object.fromEntries(segmentNames.map(s => [s, true])));
     const [activeOnly, setActiveOnly] = useState(false);
     const [commuterOnly, setCommuterOnly] = useState(false);
     const [bsFilter, setBsFilter] = useState("");
     const [groupFilter, setGroupFilter] = useState<string[]>([]);
-    const [sortField, setSortField] = useState<
-      'last'|'first'|'brother_sister'|'commuter'|'active'|
-      'avail_mon'|'avail_tue'|'avail_wed'|'avail_thu'|'avail_fri'|
-      'AM'|'Lunch'|'PM'
-    >('last');
+    const [sortField, setSortField] = useState<string>('last');
     const [sortDir, setSortDir] = useState<'asc'|'desc'>('asc');
     const [startMonth, setStartMonth] = useState<string>("");
     const [endMonth, setEndMonth] = useState<string>("");
@@ -1314,21 +1192,21 @@ async function exportShifts() {
         .filter((p:any) => {
           if (groupFilter.length === 0) return true;
           return monthsToCheck.some(m => (
-            ['AM','Lunch','PM'] as const).some(seg => {
+            segmentNames.some(seg => {
               const def = defs.find(d=>d.month===m && d.person_id===p.id && d.segment===seg);
               const role = roles.find(r=>r.id===def?.role_id);
               return role && groupFilter.includes(role.group_name);
             })
-          );
+          ));
         })
         .filter((p:any) => {
           const roleNames = monthsToCheck.flatMap(m => (
-            ['AM','Lunch','PM'] as const).map(seg => {
+            segmentNames.map(seg => {
               const def = defs.find(d=>d.month===m && d.person_id===p.id && d.segment===seg);
               const role = roles.find(r=>r.id===def?.role_id);
               return role?.name || '';
             })
-          );
+          ));
           const text = [
             p.first_name,
             p.last_name,
@@ -1362,30 +1240,36 @@ async function exportShifts() {
             case 'avail_wed': av = a.avail_wed; bv = b.avail_wed; break;
             case 'avail_thu': av = a.avail_thu; bv = b.avail_thu; break;
             case 'avail_fri': av = a.avail_fri; bv = b.avail_fri; break;
-            case 'AM':
-            case 'Lunch':
-            case 'PM':
-              const month = filterMonth || months[0];
-              const defA = defs.find(d=>d.month===month && d.person_id===a.id && d.segment===sortField);
-              const defB = defs.find(d=>d.month===month && d.person_id===b.id && d.segment===sortField);
-              const roleA = roles.find(r=>r.id===defA?.role_id)?.name || '';
-              const roleB = roles.find(r=>r.id===defB?.role_id)?.name || '';
-              av = roleA; bv = roleB; break;
             default:
-              av = ''; bv = ''; break;
+              if (segmentNames.includes(sortField)) {
+                const month = filterMonth || months[0];
+                const defA = defs.find(d=>d.month===month && d.person_id===a.id && d.segment===sortField);
+                const defB = defs.find(d=>d.month===month && d.person_id===b.id && d.segment===sortField);
+                const roleA = roles.find(r=>r.id===defA?.role_id)?.name || '';
+                const roleB = roles.find(r=>r.id===defB?.role_id)?.name || '';
+                av = roleA; bv = roleB;
+              } else {
+                av = ''; bv = '';
+              }
+              break;
           }
           if(av < bv) return sortDir==='asc' ? -1 : 1;
           if(av > bv) return sortDir==='asc' ? 1 : -1;
           return 0;
         });
-    }, [people, defs, roles, months, filter, activeOnly, commuterOnly, bsFilter, groupFilter, sortField, sortDir, filterMonth]);
+    }, [people, defs, roles, months, filter, activeOnly, commuterOnly, bsFilter, groupFilter, sortField, sortDir, filterMonth, segmentNames]);
 
-    const segs = ([] as Exclude<Segment,'Early'>[]);
-    if (showSeg.AM) segs.push('AM');
-    if (showSeg.Lunch) segs.push('Lunch');
-    if (showSeg.PM) segs.push('PM');
+    useEffect(() => {
+      setShowSeg(prev => {
+        const next: Record<string, boolean> = {};
+        segmentNames.forEach(s => { next[s] = prev[s] ?? true; });
+        return next;
+      });
+    }, [segmentNames]);
 
-    function RoleSelect({ month, personId, seg, def }: { month: string; personId: number; seg: Exclude<Segment,'Early'>; def: any }){
+    const segs: Segment[] = segmentNames.filter(s => showSeg[s]);
+
+    function RoleSelect({ month, personId, seg, def }: { month: string; personId: number; seg: Segment; def: any }){
       const ref = useRef<HTMLSelectElement>(null);
       const options = roleListForSegment(seg);
 
@@ -1412,23 +1296,23 @@ async function exportShifts() {
         <select
           ref={ref}
           className="border rounded px-2 py-1 w-full"
-          value={def?.role_id||""}
+          value={def?.role_id?.toString() || ""}
           onFocus={showNames}
           onBlur={showCode}
           onChange={(e)=>{
-            const rid = Number(e.target.value);
-            setMonthlyDefaultForMonth(month, personId, seg, rid||null);
+            const rid = parseInt(e.target.value, 10);
+            setMonthlyDefaultForMonth(month, personId, seg, isNaN(rid) ? null : rid);
             setDefs(all(`SELECT * FROM monthly_default`));
             showCode();
           }}
         >
           <option value=""></option>
-          {options.map((r:any)=>(<option key={r.id} value={r.id}>{r.name}</option>))}
+          {options.map((r:any)=>(<option key={r.id} value={r.id.toString()}>{r.name}</option>))}
         </select>
       );
     }
 
-    function cellData(month:string, personId:number, seg:Exclude<Segment,'Early'>){
+    function cellData(month:string, personId:number, seg:Segment){
       const def = defs.find((d:any)=>d.month===month && d.person_id===personId && d.segment===seg);
       const role = roles.find((r:any)=>r.id===def?.role_id);
       const color = role ? role.group_color : undefined;
@@ -1453,9 +1337,9 @@ async function exportShifts() {
             <Option value="avail_wed">Wed</Option>
             <Option value="avail_thu">Thu</Option>
             <Option value="avail_fri">Fri</Option>
-            <Option value="AM">AM Role</Option>
-            <Option value="Lunch">Lunch Role</Option>
-            <Option value="PM">PM Role</Option>
+            {segmentNames.map(seg => (
+              <Option key={seg} value={seg}>{seg} Role</Option>
+            ))}
           </Dropdown>
           <Button onClick={()=>setSortDir(sortDir==='asc'?'desc':'asc')}>{sortDir==='asc'?'Asc':'Desc'}</Button>
           <Dropdown selectedOptions={[bsFilter]} onOptionSelect={(_, data)=>setBsFilter(data.optionValue as string)}>
@@ -1483,9 +1367,14 @@ async function exportShifts() {
           </Dropdown>
           <Checkbox label="Active" checked={activeOnly} onChange={(_, data)=>setActiveOnly(!!data.checked)} />
           <Checkbox label="Commuter" checked={commuterOnly} onChange={(_, data)=>setCommuterOnly(!!data.checked)} />
-          <Checkbox label="AM" checked={showSeg.AM} onChange={(_, data)=>setShowSeg({...showSeg, AM:!!data.checked})} />
-          <Checkbox label="Lunch" checked={showSeg.Lunch} onChange={(_, data)=>setShowSeg({...showSeg, Lunch:!!data.checked})} />
-          <Checkbox label="PM" checked={showSeg.PM} onChange={(_, data)=>setShowSeg({...showSeg, PM:!!data.checked})} />
+          {segmentNames.map(seg => (
+            <Checkbox
+              key={seg}
+              label={seg}
+              checked={!!showSeg[seg]}
+              onChange={(_, data)=>setShowSeg({ ...showSeg, [seg]: !!data.checked })}
+            />
+          ))}
           <Checkbox label="Edit past months" checked={editPast} onChange={(_, data)=>setEditPast(!!data.checked)} />
           <div className="flex items-center gap-1">
             <label className="text-sm">From</label>
@@ -1557,19 +1446,16 @@ async function exportShifts() {
               {roles.filter((r)=>r.group_id===g.id).map((r:any)=> (
                 <div key={r.id} className="mb-4 border rounded p-3">
                   <div className="font-medium mb-3">{r.name}</div>
-                  <div className="space-y-3 sm:grid sm:grid-cols-3 sm:gap-3 sm:space-y-0">
-                    <div>
-                      <div className="text-xs text-slate-500 mb-1">AM Required</div>
-                      <RequiredCell date={null} group={g} role={r} segment={'AM'} />
-                    </div>
-                    <div>
-                      <div className="text-xs text-slate-500 mb-1">Lunch Required</div>
-                      <RequiredCell date={null} group={g} role={r} segment={'Lunch'} />
-                    </div>
-                    <div>
-                      <div className="text-xs text-slate-500 mb-1">PM Required</div>
-                      <RequiredCell date={null} group={g} role={r} segment={'PM'} />
-                    </div>
+                  <div
+                    className="space-y-3 sm:grid sm:gap-3 sm:space-y-0"
+                    style={{ gridTemplateColumns: `repeat(${segments.length}, minmax(0,1fr))` }}
+                  >
+                    {segments.map((s) => (
+                      <div key={s.name}>
+                        <div className="text-xs text-slate-500 mb-1">{s.name} Required</div>
+                        <RequiredCell date={null} group={g} role={r} segment={s.name as Segment} />
+                      </div>
+                    ))}
                   </div>
                 </div>
               ))}
@@ -1859,19 +1745,16 @@ function PeopleEditor(){
                   {roles.filter((r)=>r.group_id===g.id).map((r:any)=> (
                     <div key={r.id} className="mb-4 border rounded p-3">
                       <div className="font-medium mb-3">{r.name}</div>
-                      <div className="space-y-3 sm:grid sm:grid-cols-3 sm:gap-3 sm:space-y-0">
-                        <div>
-                          <div className="text-xs text-slate-500 mb-1">AM Required</div>
-                          <RequiredCell date={d} group={g} role={r} segment={'AM'} />
-                        </div>
-                        <div>
-                          <div className="text-xs text-slate-500 mb-1">Lunch Required</div>
-                          <RequiredCell date={d} group={g} role={r} segment={'Lunch'} />
-                        </div>
-                        <div>
-                          <div className="text-xs text-slate-500 mb-1">PM Required</div>
-                          <RequiredCell date={d} group={g} role={r} segment={'PM'} />
-                        </div>
+                      <div
+                        className="space-y-3 sm:grid sm:gap-3 sm:space-y-0"
+                        style={{ gridTemplateColumns: `repeat(${segments.length}, minmax(0,1fr))` }}
+                      >
+                        {segments.map((s) => (
+                          <div key={s.name}>
+                            <div className="text-xs text-slate-500 mb-1">{s.name} Required</div>
+                            <RequiredCell date={d} group={g} role={r} segment={s.name as Segment} />
+                          </div>
+                        ))}
                       </div>
                     </div>
                   ))}

--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -8,8 +8,8 @@ import PersonName from "./PersonName";
 const Grid = WidthProvider(GridLayout);
 
 interface DailyRunBoardProps {
-  activeRunSegment: Exclude<Segment, "Early">;
-  setActiveRunSegment: (seg: Exclude<Segment, "Early">) => void;
+  activeRunSegment: Segment;
+  setActiveRunSegment: (seg: Segment) => void;
   groups: any[];
   segments: SegmentRow[];
   lockEmail: string;
@@ -26,7 +26,7 @@ interface DailyRunBoardProps {
   canEdit: boolean;
   peopleOptionsForSegment: (
     date: Date,
-    segment: Exclude<Segment, "Early">,
+    segment: Segment,
     role: any
   ) => Array<{ id: number; label: string; blocked: boolean }>;
   getRequiredFor: (
@@ -66,7 +66,7 @@ export default function DailyRunBoard({
   addAssignment,
   deleteAssignment,
 }: DailyRunBoardProps) {
-  const seg: Exclude<Segment, "Early"> = activeRunSegment;
+  const seg: Segment = activeRunSegment;
   const [layout, setLayout] = useState<any[]>([]);
   const [layoutLoaded, setLayoutLoaded] = useState(false);
   const [moveContext, setMoveContext] = useState<{
@@ -272,19 +272,17 @@ export default function DailyRunBoard({
           />
         </div>
         <div className="flex gap-2">
-          {segments
-            .filter((s) => s.name !== "Early")
-            .map((s) => (
-              <button
-                key={s.name}
-                className={`px-3 py-1 rounded text-sm ${
-                  activeRunSegment === s.name ? "bg-indigo-600 text-white" : "bg-slate-200"
-                }`}
-                onClick={() => setActiveRunSegment(s.name as Exclude<Segment, "Early">)}
-              >
-                {s.name}
-              </button>
-            ))}
+          {segments.map((s) => (
+            <button
+              key={s.name}
+              className={`px-3 py-1 rounded text-sm ${
+                activeRunSegment === s.name ? "bg-indigo-600 text-white" : "bg-slate-200"
+              }`}
+              onClick={() => setActiveRunSegment(s.name as Segment)}
+            >
+              {s.name}
+            </button>
+          ))}
         </div>
         <div className="flex flex-wrap gap-2 lg:ml-auto">
           <button


### PR DESCRIPTION
## Summary
- show all defined segments in daily run board and editing modals
- render dynamic segments across monthly defaults and crew history views
- migrate database tables to reference segment names instead of fixed lists
- preserve existing monthly default data when upgrading schema
- ensure monthly defaults and crew history selections persist for custom segments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_689fd0fe46688322a435fc5845d6fee8