### PR TITLE
fix: persist early segment need overrides

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -661,7 +661,6 @@ export default function App() {
 
   // Needs
   function getRequiredFor(date: Date, groupId: number, roleId: number, segment: Segment): number {
-    if (segment === "Early") return 0; // Breakfast baseline usually 0 unless set
     const dY = ymd(date);
     const ov = all(`SELECT required FROM needs_override WHERE date=? AND group_id=? AND role_id=? AND segment=?`, [dY, groupId, roleId, segment]);
     if (ov.length) return ov[0].required;


### PR DESCRIPTION
## Summary
- allow early segment need overrides to be loaded

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*


------
https://chatgpt.com/codex/tasks/task_e_689ff88d5a4883229e1c67cee1c34a6d