### PR TITLE
Prevent sidebar tooltips from blocking button clicks

### DIFF
--- a/src/components/SideRail.tsx
+++ b/src/components/SideRail.tsx
@@ -13,6 +13,7 @@ import {
   WeatherSunny20Regular,
   WeatherMoon20Regular,
 } from "@fluentui/react-icons";
+import "../styles/tooltip.css";
 
 export type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
 

--- a/src/styles/tooltip.css
+++ b/src/styles/tooltip.css
@@ -1,0 +1,3 @@
+.fui-Tooltip__content {
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- prevent sidebar tooltips from capturing pointer events so buttons remain clickable

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac6c713aa08322a7761a54e8e09be1