### PR TITLE
Add monthly shift notes

### DIFF
--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -60,6 +60,17 @@ export const migrate11AddTrainingSource: Migration = (db) => {
   }
 };
 
+export const migrate12AddMonthlyNotes: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS monthly_default_note (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      month TEXT NOT NULL,
+      person_id INTEGER NOT NULL,
+      note TEXT NOT NULL,
+      UNIQUE(month, person_id),
+      FOREIGN KEY (person_id) REFERENCES person(id)
+    );`);
+};
+
 export const migrate6AddExportGroup: Migration = (db) => {
   db.run(`CREATE TABLE IF NOT EXISTS export_group (
       group_id INTEGER PRIMARY KEY,
@@ -558,6 +569,7 @@ const migrations: Record<number, Migration> = {
   9: migrate8FixSegmentConstraints, // Run the same migration again as 9 to fix failed migration 8
   10: migrate10BackfillGroupCustomColor,
   11: migrate11AddTrainingSource,
+  12: migrate12AddMonthlyNotes,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- add database migration for monthly default notes
- allow editing monthly notes in Monthly Defaults with tooltip display
- include notes when exporting shifts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bfe02388322a96497c8146967b8