### PR TITLE
feat: add monthly notes for defaults

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,6 +148,7 @@ export default function App() {
   const [monthlyDefaults, setMonthlyDefaults] = useState<any[]>([]);
   const [monthlyEditing, setMonthlyEditing] = useState(false);
   const [monthlyOverrides, setMonthlyOverrides] = useState<any[]>([]);
+  const [monthlyNotes, setMonthlyNotes] = useState<any[]>([]);
 
   // UI: simple dialogs
   const [showNeedsEditor, setShowNeedsEditor] = useState(false);
@@ -535,8 +536,10 @@ export default function App() {
     setMonthlyDefaults(rows);
     const ov = all(`SELECT * FROM monthly_default_day WHERE month=?`, [month]);
     setMonthlyOverrides(ov);
-  // Reflect changes to training from monthly assignments
-  syncTrainingFromMonthly();
+    const notes = all(`SELECT * FROM monthly_default_note WHERE month=?`, [month]);
+    setMonthlyNotes(notes);
+    // Reflect changes to training from monthly assignments
+    syncTrainingFromMonthly();
   }
 
   function setMonthlyDefault(personId: number, segment: Segment, roleId: number | null) {
@@ -565,6 +568,20 @@ export default function App() {
     }
   loadMonthlyDefaults(selectedMonth);
   syncTrainingFromMonthly();
+  }
+
+  function setMonthlyNote(personId: number, note: string | null) {
+    if (!sqlDb) return;
+    const text = note?.trim();
+    if (text) {
+      run(`INSERT INTO monthly_default_note (month, person_id, note) VALUES (?,?,?)
+           ON CONFLICT(month, person_id) DO UPDATE SET note=excluded.note`,
+          [selectedMonth, personId, text]);
+    } else {
+      run(`DELETE FROM monthly_default_note WHERE month=? AND person_id=?`,
+          [selectedMonth, personId]);
+    }
+    loadMonthlyDefaults(selectedMonth);
   }
 
   function setMonthlyDefaultForMonth(month: string, personId: number, segment: Segment, roleId: number | null) {
@@ -596,6 +613,14 @@ export default function App() {
         `INSERT INTO monthly_default_day (month, person_id, weekday, segment, role_id) VALUES (?,?,?,?,?)
          ON CONFLICT(month, person_id, weekday, segment) DO UPDATE SET role_id=excluded.role_id`,
         [toMonth, row.person_id, row.weekday, row.segment, row.role_id]
+      );
+    }
+    const nrows = all(`SELECT person_id, note FROM monthly_default_note WHERE month=?`, [fromMonth]);
+    for (const row of nrows) {
+      run(
+        `INSERT INTO monthly_default_note (month, person_id, note) VALUES (?,?,?)
+         ON CONFLICT(month, person_id) DO UPDATE SET note=excluded.note`,
+        [toMonth, row.person_id, row.note]
       );
     }
     loadMonthlyDefaults(toMonth);
@@ -1439,10 +1464,12 @@ function PeopleEditor(){
               segments={segments}
               monthlyDefaults={monthlyDefaults}
               monthlyOverrides={monthlyOverrides}
+              monthlyNotes={monthlyNotes}
               monthlyEditing={monthlyEditing}
               setMonthlyEditing={setMonthlyEditing}
               setMonthlyDefault={setMonthlyDefault}
               setWeeklyOverride={setWeeklyOverride}
+              setMonthlyNote={setMonthlyNote}
               copyMonthlyDefaults={copyMonthlyDefaults}
               applyMonthlyDefaults={applyMonthlyDefaults}
               exportMonthlyDefaults={exportMonthlyDefaults}

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -60,6 +60,18 @@ export const migrate11AddTrainingSource: Migration = (db) => {
   }
 };
 
+// 12. Add table for monthly default notes
+export const migrate12AddMonthlyNotes: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS monthly_default_note (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      month TEXT NOT NULL,
+      person_id INTEGER NOT NULL,
+      note TEXT,
+      UNIQUE(month, person_id),
+      FOREIGN KEY (person_id) REFERENCES person(id)
+    );`);
+};
+
 export const migrate6AddExportGroup: Migration = (db) => {
   db.run(`CREATE TABLE IF NOT EXISTS export_group (
       group_id INTEGER PRIMARY KEY,
@@ -558,6 +570,7 @@ const migrations: Record<number, Migration> = {
   9: migrate8FixSegmentConstraints, // Run the same migration again as 9 to fix failed migration 8
   10: migrate10BackfillGroupCustomColor,
   11: migrate11AddTrainingSource,
+  12: migrate12AddMonthlyNotes,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- allow storing notes per person/month via new migration table
- add state and database hooks for managing monthly notes
- provide notes button with tooltip and modal editing on Monthly Defaults page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bfe02388322a96497c8146967b8